### PR TITLE
GCC <= 4.X Support

### DIFF
--- a/pg_show_plans.c
+++ b/pg_show_plans.c
@@ -365,7 +365,7 @@ show_format()
 		elog(ERROR, "unexpected plan_format value: %d", pgsp->plan_format);
 }
 
-inline void
+static inline void
 shmem_safety_check(void)
 {
 	if (pgsp && pgsp_hash)


### PR DESCRIPTION
There are some problems in the definition of this function "shmem_safety_check". 
In the case of -std=gnu99, there will be warnings and even compile errors.

The warning message is as follows:
gcc -std=gnu99...
pg_show_plans.c:371:14:warning: pgsp_hash is static but used in inline function shmem_safety_check which is not static.
The error messages is as follows:
/usr/bin/ld: pg_show_plans.o : relocation R_X86_64_PC32 against undefined symbol "shmem_safety_check" can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed : Bad value


