### PR TITLE
Drop erratic role checking

### DIFF
--- a/pg_show_plans.c
+++ b/pg_show_plans.c
@@ -319,7 +319,7 @@ set_state(bool state, void *extra)
 	 * commented out. */
 	/* shmem_safety_check(); */
 
-	if (pgsp != NULL && is_allowed_role())
+	if (pgsp != NULL)
 		pgsp->is_enabled = state;
 }
 


### PR DESCRIPTION
Config reload gets initiated by the operating system (signal), NOT by a user/role.