### PR TITLE
Fix config reload crash for <=14

### DIFF
--- a/pg_show_plans.c
+++ b/pg_show_plans.c
@@ -159,7 +159,11 @@ _PG_init(void)
 	                         NULL,
 	                         &start_enabled,
 	                         true,
+#if PG_VERSION_NUM >= 150000
 	                         PGC_USERSET,
+#else
+	                         PGC_POSTMASTER,
+#endif
 	                         0,
 	                         NULL, set_state, show_state);
 	DefineCustomIntVariable("pg_show_plans.max_plan_length",
@@ -183,7 +187,11 @@ _PG_init(void)
 	                         &plan_format,
 	                         EXPLAIN_FORMAT_TEXT,
 	                         plan_formats,
+#if PG_VERSION_NUM >= 150000
 	                         PGC_USERSET,
+#else
+	                         PGC_POSTMASTER,
+#endif
 	                         0,
 	                         NULL, prop_format_to_shmem, show_format);
 


### PR DESCRIPTION
`SysLoggerMain()` does not have shared memory acess, therefore crashes on attempts to access it.