### PR TITLE
Fix 14 tests failures

### DIFF
--- a/.github/workflows/installcheck.yml
+++ b/.github/workflows/installcheck.yml
@@ -19,6 +19,7 @@ jobs:
           - 17
           - 16
           - 15
+          - 14
 
     env:
       PGVERSION: ${{ matrix.pgversion }}

--- a/expected/formats_2.out
+++ b/expected/formats_2.out
@@ -1,0 +1,66 @@
+-- explain output on PG12/13 is missing "Async Capable"
+select setting::int < 140000 as pg12_13 from pg_settings where name = 'server_version_num';
+ pg12_13 
+---------
+ f
+(1 row)
+
+-- json output
+set pg_show_plans.plan_format = 'json';
+ERROR:  parameter "pg_show_plans.plan_format" cannot be changed without restarting the server
+show pg_show_plans.plan_format;
+ pg_show_plans.plan_format 
+---------------------------
+ text
+(1 row)
+
+select * from nest();
+ level |                                 plan                                 
+-------+----------------------------------------------------------------------
+     0 | Function Scan on nest  (cost=0.25..10.25 rows=1000 width=36)
+     1 | Function Scan on pg_show_plans  (cost=0.00..12.50 rows=333 width=36)+
+       |   Filter: (level >= 0)
+(2 rows)
+
+-- yaml output
+set pg_show_plans.plan_format = 'yaml';
+ERROR:  parameter "pg_show_plans.plan_format" cannot be changed without restarting the server
+show pg_show_plans.plan_format;
+ pg_show_plans.plan_format 
+---------------------------
+ text
+(1 row)
+
+select * from nest();
+ level |                                 plan                                 
+-------+----------------------------------------------------------------------
+     0 | Function Scan on nest  (cost=0.25..10.25 rows=1000 width=36)
+     1 | Function Scan on pg_show_plans  (cost=0.00..12.50 rows=333 width=36)+
+       |   Filter: (level >= 0)
+(2 rows)
+
+-- xml output
+set pg_show_plans.plan_format = 'xml';
+ERROR:  parameter "pg_show_plans.plan_format" cannot be changed without restarting the server
+show pg_show_plans.plan_format;
+ pg_show_plans.plan_format 
+---------------------------
+ text
+(1 row)
+
+select * from nest();
+ level |                                 plan                                 
+-------+----------------------------------------------------------------------
+     0 | Function Scan on nest  (cost=0.25..10.25 rows=1000 width=36)
+     1 | Function Scan on pg_show_plans  (cost=0.00..12.50 rows=333 width=36)+
+       |   Filter: (level >= 0)
+(2 rows)
+
+-- check plan format after reconnect
+\c
+show pg_show_plans.plan_format;
+ pg_show_plans.plan_format 
+---------------------------
+ text
+(1 row)
+

--- a/expected/pg_show_plans_1.out
+++ b/expected/pg_show_plans_1.out
@@ -1,0 +1,46 @@
+create extension pg_show_plans;
+show pg_show_plans.is_enabled;
+ pg_show_plans.is_enabled 
+--------------------------
+ on
+(1 row)
+
+show pg_show_plans.max_plan_length;
+ pg_show_plans.max_plan_length 
+-------------------------------
+ 16384
+(1 row)
+
+create function nest()
+  returns table (level int, plan text)
+  language plpgsql
+as $$
+  begin
+    return query
+      select pg_show_plans.level, pg_show_plans.plan from pg_show_plans
+        where pg_show_plans.level >= 0;
+  end;
+$$;
+-- text output
+set pg_show_plans.plan_format = 'text';
+ERROR:  parameter "pg_show_plans.plan_format" cannot be changed without restarting the server
+show pg_show_plans.plan_format;
+ pg_show_plans.plan_format 
+---------------------------
+ text
+(1 row)
+
+select level, plan from pg_show_plans;
+ level |                                 plan                                  
+-------+-----------------------------------------------------------------------
+     0 | Function Scan on pg_show_plans  (cost=0.00..10.00 rows=1000 width=36)
+(1 row)
+
+select * from nest();
+ level |                                 plan                                 
+-------+----------------------------------------------------------------------
+     0 | Function Scan on nest  (cost=0.25..10.25 rows=1000 width=36)
+     1 | Function Scan on pg_show_plans  (cost=0.00..12.50 rows=333 width=36)+
+       |   Filter: (level >= 0)
+(2 rows)
+


### PR DESCRIPTION
Versions <=14 cannot acces shared memory from GUC functions, and therefore cannot change plan format without server restart (unlike
>=15). Different `installcheck` results are expected.